### PR TITLE
Add plugin `esbuild-plugin-http-imports`

### DIFF
--- a/build/js/build.ts
+++ b/build/js/build.ts
@@ -1,5 +1,5 @@
 import type { BuildOptions } from "../../deps.ts";
-import { build as esbuild } from "../../deps.ts";
+import { build as esbuild, httpImports } from "../../deps.ts";
 
 /**
  * Builds JS from a given source file.
@@ -15,6 +15,7 @@ export async function build(
     outfile: outPath,
     bundle: true,
     minify: true,
+    plugins: [httpImports()],
     ...opts,
   });
 

--- a/deno.lock
+++ b/deno.lock
@@ -31,6 +31,7 @@
     "https://deno.land/x/denoflate@1.2.1/pkg/denoflate_bg.wasm.js": "d581956245407a2115a3d7e8d85a9641c032940a8e810acbd59ca86afd34d44d",
     "https://deno.land/x/esbuild@v0.16.17/mod.d.ts": "f0226ff211effd61673e1a6d3f8d4bd601a0d7854f69f9c91ecbeeff21e31829",
     "https://deno.land/x/esbuild@v0.16.17/mod.js": "abf56956177f7bd0c5b49f1d00a6c793ea3b00eff3242385fd14de80d94875d1",
+    "https://deno.land/x/esbuild_plugin_http_imports@v1.2.4/index.ts": "a71e0483757a0c838bd6799c101cfe7a25513fd4a4905870b0d1d35d2ed96af3",
     "https://deno.land/x/slash@v0.3.0/mod.ts": "bac6b63a39878f394667a45121f59c8919ae8747b953a275aaf089058c031e7e"
   }
 }

--- a/deps.ts
+++ b/deps.ts
@@ -4,5 +4,6 @@ export { expandGlob } from "https://deno.land/std@0.171.0/fs/mod.ts";
 
 export type { BuildOptions } from "https://deno.land/x/esbuild@v0.16.17/mod.js";
 export { build, transform } from "https://deno.land/x/esbuild@v0.16.17/mod.js";
+export { httpImports } from "https://deno.land/x/esbuild_plugin_http_imports@v1.2.4/index.ts";
 
 export { default as deslash } from "https://deno.land/x/slash@v0.3.0/mod.ts";

--- a/examples/external/README.md
+++ b/examples/external/README.md
@@ -1,0 +1,20 @@
+# External
+
+This is a simple bookmarklet. It will print `"Hello, External!" to the console
+signifying that the external module was bundled successfully.
+
+This bookmarklet was build using the following command:
+
+```bash
+deno run -A --reload https://deno.land/x/bmt/main.ts ./examples/external/main.ts
+```
+
+## Usage
+
+Copy and paste the following into your browser's address bar:
+
+```
+javascript:(()%3D%3E%7Bfunction%20e(r)%7Breturn%60Hello%2C%20%24%7Br%7D!%60%7Dconsole.log(e(%22External%22))%3B%7D)()%3B%0A
+```
+
+> Note: For reusability, you may want to add this to your bookmarks bar.

--- a/examples/external/README.tmpl.md
+++ b/examples/external/README.tmpl.md
@@ -1,0 +1,12 @@
+# External
+
+This is a simple bookmarklet. It will print `"Hello, External!" to the console
+signifying that the external module was bundled successfully.
+
+This bookmarklet was build using the following command:
+
+```bash
+deno run -A --reload https://deno.land/x/bmt/main.ts ./examples/external/main.ts
+```
+
+{{ bookmarklet:usage }}

--- a/examples/external/main.ts
+++ b/examples/external/main.ts
@@ -1,0 +1,8 @@
+/**
+ * This code is included in the bundle since this file is loaded
+ * via import statement using the
+ * <https://deno.land/x/esbuild_plugin_http_imports> plugin.
+ */
+import { greet } from "https://etok.codes/bmt/raw/main/examples/hello_world/hello_world.ts";
+
+console.log(greet("External"));


### PR DESCRIPTION
Use a new plugin to bundle external source files into the bookmarklet.

### Old behavior

Importing external source files would translate into dynamically loading the script in the resulting bundled bookmarklet.

### New behavior

Importing external source files seamlessly bundles external scripts at bundle-time.

### References

- <https://github.com/EthanThatOneKid/bmt/issues/2#issuecomment-1379802070>
- <https://deno.land/x/esbuild_plugin_http_imports@v1.2.4>